### PR TITLE
Add exclude path

### DIFF
--- a/settings/Preferences.sublime-settings
+++ b/settings/Preferences.sublime-settings
@@ -29,5 +29,6 @@
 	"tab_size": 2,
 	"theme": "Soda Light 3.sublime-theme",
 	"translate_tabs_to_spaces": true,
-	"trim_trailing_white_space_on_save": true
+	"trim_trailing_white_space_on_save": true,
+	"folder_exclude_patterns": [".git", ".hg", ".bundle", "tmp"]
 }


### PR DESCRIPTION
Exclude .bundle and tmp from search folders, because global search is very slow.
