### PR TITLE
Do not ignore .bundle folder

### DIFF
--- a/settings/Preferences.sublime-settings
+++ b/settings/Preferences.sublime-settings
@@ -30,5 +30,5 @@
 	"theme": "Soda Light 3.sublime-theme",
 	"translate_tabs_to_spaces": true,
 	"trim_trailing_white_space_on_save": true,
-	"folder_exclude_patterns": [".git", ".hg", ".bundle", "tmp"]
+	"folder_exclude_patterns": [".git", ".hg", "tmp"]
 }


### PR DESCRIPTION
We would like to review installed gems inside `.bundle` folder with SublimeText.