### PR TITLE
Add file icons and improve es6 syntax highlighting

### DIFF
--- a/settings/Package Control.sublime-settings
+++ b/settings/Package Control.sublime-settings
@@ -17,6 +17,7 @@
 		"AdvancedNewFile",
 		"All Autocomplete",
 		"Side​Bar​Enhancements",
-		"Babel"
+		"Babel",
+		"A File Icon"
 	]
 }

--- a/settings/Preferences.sublime-settings
+++ b/settings/Preferences.sublime-settings
@@ -12,7 +12,8 @@
 	"highlight_modified_tabs": true,
 	"ignored_packages":
 	[
-		"Vintage"
+		"Vintage",
+		"JavaScript"
 	],
 	"indent_guide_options":
 	[


### PR DESCRIPTION
* Add [Sublime file-specific icons for improved visual grepping](https://github.com/ihodev/a-file-icon)
* Set [Babel as the only JavaScript package](https://github.com/babel/babel-sublime#advanced-usage)